### PR TITLE
Deconstruct into individual targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 JS language shims used by Airbnb.
 
-Just require/import it, and the environment will be shimmed.
+Just require/import `airbnb-js-shims`, and the environment will be shimmed.
 
-Included shims:
+```js
+import 'airbnb-js-shims';
+```
+
+## Included shims
+
  - [es5-shim](https://www.npmjs.com/package/es5-shim)
  - [es5-sham](https://www.npmjs.com/package/es5-shim)
  - [es6-shim](https://www.npmjs.com/package/es6-shim)
@@ -13,3 +18,18 @@ Included shims:
  - [Object.values](https://www.npmjs.com/package/object.values) (stage 3, planned for ES8/ES2017)
  - [String.prototype.padStart](https://www.npmjs.com/package/string.prototype.padstart) (stage 3, planned for ES8/ES2017)
  - [String.prototype.padEnd](https://www.npmjs.com/package/string.prototype.padend) (stage 3, planned for ES8/ES2017)
+
+## Targeting versions
+
+If you do not need to support older browsers, you can pick a subset of ES versions to target. For example, if you don't support pre-ES5 browsers, you can start your shims with ES2015 by requiring/importing the specific target file. This will shim the environment for that version and upward.
+
+```js
+import 'airbnb-js-shims/target/es2015';
+```
+
+### Included targets
+
+- `airbnb-js-shims/target/es5` (default)
+- `airbnb-js-shims/target/es2015`
+- `airbnb-js-shims/target/es2016`
+- `airbnb-js-shims/target/es2017`

--- a/index.js
+++ b/index.js
@@ -1,19 +1,3 @@
 'use strict';
 
-require('es5-shim');
-require('es5-shim/es5-sham');
-require('es6-shim');
-
-// Array#includes is stage 4, in ES7/ES2016
-require('array-includes/shim')();
-
-// Object.values/Object.entries are stage 3, planned for ES8/ES2017
-require('object.values/shim')();
-require('object.entries/shim')();
-
-// String#padStart/String#padEnd are stage 3, planned for ES8/ES2017
-require('string.prototype.padstart/shim')();
-require('string.prototype.padend/shim')();
-
-// Object.getOwnPropertyDescriptors is stage 3, planned for ES8/ES2017
-require('object.getownpropertydescriptors/shim')();
+require('./target/es5');

--- a/target/es2015.js
+++ b/target/es2015.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('es6-shim');
+
+require('./es2016');

--- a/target/es2016.js
+++ b/target/es2016.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Array#includes is stage 4, in ES7/ES2016
+require('array-includes/shim')();
+
+require('./es2016');

--- a/target/es2017.js
+++ b/target/es2017.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Object.values/Object.entries are stage 3, planned for ES8/ES2017
+require('object.values/shim')();
+require('object.entries/shim')();
+
+// String#padStart/String#padEnd are stage 3, planned for ES8/ES2017
+require('string.prototype.padstart/shim')();
+require('string.prototype.padend/shim')();
+
+// Object.getOwnPropertyDescriptors is stage 3, planned for ES8/ES2017
+require('object.getownpropertydescriptors/shim')();
+
+// Eventually...
+// require('./es2018');

--- a/target/es5.js
+++ b/target/es5.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('es5-shim');
+require('es5-shim/es5-sham');
+
+require('./es2015');


### PR DESCRIPTION
As support for older browsers is dropped, we can slowly remove some of
these shims to reduce the amount of JavaScript we ship. So this can be
granular, I've split up the main entry point into separate targets. With
this organization, you simply pick the oldest version that you need to
shim with the default being ES5.