### PR TITLE
Correctly require es2017 from es2016

### DIFF
--- a/target/es2016.js
+++ b/target/es2016.js
@@ -3,4 +3,4 @@
 // Array#includes is stage 4, in ES7/ES2016
 require('array-includes/shim')();
 
-require('./es2016');
+require('./es2017');


### PR DESCRIPTION
In #4, I messed up this require, causing the es2017 shims to not be
imported.