### PR TITLE
Whitelist /target and index.js when publishing NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
 	"version": "2.2.0",
 	"description": "JS language shims used by Airbnb.",
 	"main": "index.js",
+	"files": [
+		"/target",
+		"index.js"
+	],
 	"scripts": {
 		"prepublish": "safe-publish-latest",
 		"lint": "eslint .",


### PR DESCRIPTION
I noticed that the following files and folders are distributed in the published NPM module:
![image](https://user-images.githubusercontent.com/13087421/58371670-dc7a8a00-7f45-11e9-85c9-f15a9d5497e6.png)

This PR fixes that by whitelisting `/target` and `index.js` :) 

